### PR TITLE
Fix detection of 'unreachable code' in V8

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/v8_unreachable_code.txt
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/v8_unreachable_code.txt
@@ -1,4 +1,31 @@
+[Environment] ASAN_OPTIONS=alloc_dealloc_mismatch=0:allocator_may_return_null=1:allow_user_segv_handler=1:check_malloc_usable_size=0:detect_leaks=0:detect_odr_violation=0:detect_stack_use_after_return=1:fast_unwind_on_fatal=1:handle_abort=1:handle_segv=1:handle_sigbus=1:handle_sigfpe=1:handle_sigill=1:handle_sigtrap=1:max_uar_stack_size_log=16:print_scariness=1:print_summary=1:print_suppressions=0:redzone=16:strict_memcmp=0:symbolize=0:use_sigaltstack=1
+[Command line] /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_ddc8d9b4eb72ba668f6305da25580be9a07378b8/revisions/d8-arm-asan-linux-debug-v8-component-90236/d8 --random-seed=848554365 --fuzzing --fuzzing --disable-abortjs --disable-in-process-stack-traces --jit-fuzzing --stress-concurrent-inlining --fuzzing --predictable /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/fuzz-00793.js
+
++----------------------------------------Debug Build Stacktrace----------------------------------------+
+max_maglev_inlined_bytecode_size should be added to the list of flags_ignored_because_of_predictable
+
+
 #
-# Fatal error in ../../v8/src/compiler/typer.cc, line 1626
+# Fatal error in ../../src/flags/flags.cc, line 624
 # unreachable code
 #
+#
+#
+#FailureMessage Object: 0xe9983820AddressSanitizer:DEADLYSIGNAL
+=================================================================
+==1208088==ERROR: AddressSanitizer: ABRT on unknown address 0x00126f18 (pc 0xf7f5f509 bp 0xffe8d3cc sp 0xffe8d3b0 T0)
+SCARINESS: 10 (signal)
+    #0 0xf7f5f509 in linux-gate.so.1
+
+AddressSanitizer can not provide additional info.
+SUMMARY: AddressSanitizer: ABRT (linux-gate.so.1+0x509) (BuildId: 6382268d66646df6766698659dfb73c8c56c2712)
+==1208088==ABORTING
+
+
++----------------------------------------Debug Build Unsymbolized Stacktrace (diff)----------------------------------------+
+
+==1208088==ERROR: AddressSanitizer: ABRT on unknown address 0x00126f18 (pc 0xf7f5f509 bp 0xffe8d3cc sp 0xffe8d3b0 T0)
+SCARINESS: 10 (signal)
+    #0 0xf7f5f509  (linux-gate.so.1+0x509) (BuildId: 6382268d66646df6766698659dfb73c8c56c2712)
+
+AddressSanitizer can not provide additional info.

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -1061,7 +1061,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     data = self._read_test_data('v8_unreachable_code.txt')
     expected_type = 'Unreachable code'
     expected_address = ''
-    expected_state = 'typer.cc\n'
+    expected_state = 'flags.cc\n'
     expected_stacktrace = data
     expected_security_flag = False
 

--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -629,7 +629,9 @@ IGNORE_CRASH_TYPES_FOR_ABRT_BREAKPOINT_AND_ILLS = [
     'Fatal error',
     'Security CHECK failure',
     'Security DCHECK failure',
+    'Unreachable code',
     'V8 API error',
+    'V8 sandbox violation',
 ]
 
 STATE_STOP_MARKERS = [


### PR DESCRIPTION
Do not overwrite the already-detected 'unreachable code' state with the ASan abort.