### PR TITLE
Fix classification of CSA_DCHECKs in V8

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/v8_csa_dcheck.txt
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/v8_csa_dcheck.txt
@@ -1,0 +1,125 @@
+[Environment] ASAN_OPTIONS=alloc_dealloc_mismatch=0:allocator_may_return_null=1:allow_user_segv_handler=1:check_malloc_usable_size=0:detect_leaks=1:detect_odr_violation=0:detect_stack_use_after_return=1:external_symbolizer_path=/mnt/scratch0/clusterfuzz/resources/platform/linux/llvm-symbolizer:fast_unwind_on_fatal=1:handle_abort=1:handle_segv=1:handle_sigbus=1:handle_sigfpe=1:handle_sigill=1:handle_sigtrap=1:print_scariness=1:print_summary=1:print_suppressions=0:redzone=32:strict_memcmp=0:symbolize=1:symbolize_inline_frames=false:use_sigaltstack=1
+[Command line] /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-debug_1f17dda3b0e56007440db98eafbaad9618b3d0fa/revisions/d8 --random-seed=1710077318 --fuzzing --fuzzing --disable-abortjs --disable-in-process-stack-traces --no-stress-lazy-source-positions --turbo-instruction-scheduling --jit-fuzzing --no-wasm-generic-wrapper --no-enable-sse4_1 --fuzzing /mnt/scratch0/clusterfuzz/bot/inputs/disk/fuzz-28.js
+
++----------------------------------------Debug Build Stacktrace----------------------------------------+
+abort: CSA_DCHECK failed: Torque assert 'data.wrapper_budget > 0' failed [src/builtins/wasm-to-js.tq:66] [src/builtins/builtins-wasm-gen.cc:164]
+
+==== JS stack trace =========================================
+
+    0: ExitFrame [pc: 0x76efbf82c13d]
+    1: StubFrame [pc: 0x76efbf7fcc11]
+    2: TurbofanStubWithContextFrame [pc: 0x76efa0000f7f]
+    3: /* anonymous */ [0x7ecc00099b89] [/mnt/scratch0/clusterfuzz/bot/inputs/disk/fuzz-28.js:136] [bytecode=0x7e90000400c5 offset=347](this=0x7ecc0008177d <JSGlobalProxy>#0#)
+    4: InternalFrame [pc: 0x76efbf43ea9c]
+    5: EntryFrame [pc: 0x76efbf43e7df]
+
+==== Details ================================================
+
+[0]: ExitFrame [pc: 0x76efbf82c13d]
+[1]: StubFrame [pc: 0x76efbf7fcc11]
+[2]: TurbofanStubWithContextFrame [pc: 0x76efa0000f7f]
+[3]: /* anonymous */ [0x7ecc00099b89] [/mnt/scratch0/clusterfuzz/bot/inputs/disk/fuzz-28.js:136] [bytecode=0x7e90000400c5 offset=347](this=0x7ecc0008177d <JSGlobalProxy>#0#) {
+  // heap-allocated locals
+  var kTypeSectionCode = 0x7ecc00289415 <FixedArray[11]>#1#
+  var kImportSectionCode = 1
+  var kExportSectionCode = 2
+  var kWasmFunctionTypeForm = 7
+  var kNoSuperType = 96
+  var kSig_v_v = 0x7ecc000000c9 <true>
+  var Binary = 0x7ecc00289865 <Object map = 0x7ecc00082511>#2#
+  var WasmModuleBuilder = 0x7ecc00289895 <JSFunction Binary (sfi = 0x7ecc00099245)>#3#
+  var __v_5 = 0x7ecc00289aa5 <JSFunction WasmModuleBuilder (sfi = 0x7ecc000993f5)>#4#
+  var __v_6 = 0x7ecc00000069 <undefined>
+  var __v_7 = 0x7ecc00000069 <undefined>
+  // expression stack (top to bottom)
+  [14] : 0x7ecc0028a6a1 <Object map = 0x7ecc0009b0ad>#5#
+  [13] : 0x7ecc00289979 <JSFunction emit_section (sfi = 0x7ecc000993c5)>#6#
+  [12] : 0x7ecc0028995d <JSFunction emit_header (sfi = 0x7ecc00099395)>#7#
+  [11] : 0x7ecc00289b65 <JSFunction toModule (sfi = 0x7ecc00099515)>#8#
+  [10] : 0x7ecc00289b49 <JSFunction instantiate (sfi = 0x7ecc000994e5)>#9#
+  [09] : 0x7ecc00289b19 <JSFunction toBuffer (sfi = 0x7ecc000994b5)>#10#
+  [08] : 0x7ecc00289afd <JSFunction addExport (sfi = 0x7ecc00099485)>#11#
+  [07] : 0x7ecc00289ae1 <JSFunction addImport (sfi = 0x7ecc00099455)>#12#
+  [06] : 0x7ecc00289ac5 <JSFunction addType (sfi = 0x7ecc00099425)>#13#
+  [05] : 0x7ecc00000791 <the_hole_value>#14#
+  [04] : 0x7ecc00289f35 <Object map = 0x7ecc0009a8a9>#15#
+  [03] : 0x7ecc00289f09 <Object map = 0x7ecc0009a84d>#16#
+  [02] : 0x7ecc0028a6a1 <Object map = 0x7ecc0009b0ad>#5#
+  [01] : 0x7ecc0009b069 <JSFunction js-to-wasm:: (sfi = 0x7ecc0009b039)>#17#
+  [00] : 0x7ecc00000069 <undefined>
+--------- s o u r c e   c o d e ---------
+var kWasmH0 = 0;\x0avar kWasmH1 = 0x61;\x0avar kWasmH2 = 0x73;\x0avar kWasmH3 = 0x6d;\x0avar kWasmV0 = 0x1;\x0avar kWasmV1 = 0;\x0avar kWasmV2 = 0;\x0avar kWasmV3 = 0;\x0alet kTypeSectionCode = 1;\x0alet kImportSectionCode = 2;\x0alet kExportSectionCode = 7;\x0alet kWasmFunctionTypeForm = 0x60;\x0alet kNoSuperType = 0xFFFFFFFF;\x0alet kS...
+
+-----------------------------------------
+}
+
+[4]: InternalFrame [pc: 0x76efbf43ea9c]
+[5]: EntryFrame [pc: 0x76efbf43e7df]
+-- ObjectCacheKey --
+
+ #0# 0x7ecc0008177d: 0x7ecc0008177d <JSGlobalProxy>
+ #1# 0x7ecc00289415: 0x7ecc00289415 <FixedArray[11]>
+                 0: 1
+                 1: 1
+                 2: 1
+                 3: 1
+                 4: 0
+                 5: 1
+                 6: 1
+                 7: 1
+                 8: 1
+                 9: 1
+                  ...
+ #2# 0x7ecc00289865: 0x7ecc00289865 <Object map = 0x7ecc00082511>
+ #3# 0x7ecc00289895: 0x7ecc00289895 <JSFunction Binary (sfi = 0x7ecc00099245)>
+ #4# 0x7ecc00289aa5: 0x7ecc00289aa5 <JSFunction WasmModuleBuilder (sfi = 0x7ecc000993f5)>
+ #5# 0x7ecc0028a6a1: 0x7ecc0028a6a1 <Object map = 0x7ecc0009b0ad>
+                 f: 0x7ecc0009b069 <JSFunction js-to-wasm:: (sfi = 0x7ecc0009b039)>#17#
+ #6# 0x7ecc00289979: 0x7ecc00289979 <JSFunction emit_section (sfi = 0x7ecc000993c5)>
+ #7# 0x7ecc0028995d: 0x7ecc0028995d <JSFunction emit_header (sfi = 0x7ecc00099395)>
+ #8# 0x7ecc00289b65: 0x7ecc00289b65 <JSFunction toModule (sfi = 0x7ecc00099515)>
+ #9# 0x7ecc00289b49: 0x7ecc00289b49 <JSFunction instantiate (sfi = 0x7ecc000994e5)>
+ #10# 0x7ecc00289b19: 0x7ecc00289b19 <JSFunction toBuffer (sfi = 0x7ecc000994b5)>
+ #11# 0x7ecc00289afd: 0x7ecc00289afd <JSFunction addExport (sfi = 0x7ecc00099485)>
+ #12# 0x7ecc00289ae1: 0x7ecc00289ae1 <JSFunction addImport (sfi = 0x7ecc00099455)>
+ #13# 0x7ecc00289ac5: 0x7ecc00289ac5 <JSFunction addType (sfi = 0x7ecc00099425)>
+ #14# 0x7ecc00000791: 0x7ecc00000791 <the_hole_value>
+ #15# 0x7ecc00289f35: 0x7ecc00289f35 <Object map = 0x7ecc0009a8a9>
+                 f: 0x7ecc00289f61 <JSFunction f (sfi = 0x7ecc00099545)>#18#
+ #16# 0x7ecc00289f09: 0x7ecc00289f09 <Object map = 0x7ecc0009a84d>
+                 m: 0x7ecc00289f35 <Object map = 0x7ecc0009a8a9>#15#
+ #17# 0x7ecc0009b069: 0x7ecc0009b069 <JSFunction js-to-wasm:: (sfi = 0x7ecc0009b039)>
+ #18# 0x7ecc00289f61: 0x7ecc00289f61 <JSFunction f (sfi = 0x7ecc00099545)>
+=====================
+
+AddressSanitizer:DEADLYSIGNAL
+=================================================================
+==480==ERROR: AddressSanitizer: ABRT on unknown address 0x0539000001e0 (pc 0x7aeff105100b bp 0x7ffe9f2d2530 sp 0x7ffe9f2d22e0 T0)
+SCARINESS: 10 (signal)
+    #0 0x7aeff105100b in raise /build/glibc-LcI20x/glibc-2.31/signal/../sysdeps/unix/sysv/linux/raise.c:51:1
+    #1 0x7aeff9810bc0 in v8::internal::__RT_impl_Runtime_AbortCSADcheck(v8::internal::Arguments<(v8::internal::ArgumentsType)0>, v8::internal::Isolate*) src/runtime/runtime-test.cc:1515:3
+    #2 0x7aeff9810109 in v8::internal::Runtime_AbortCSADcheck(int, unsigned long*, v8::internal::Isolate*) src/runtime/runtime-test.cc:1496:1
+    #3 0x76efbf82c13c in Builtins_AsyncFromSyncIteratorPrototypeReturn setup-isolate-deserialize.cc
+    #4 0x76efbf7fcc10 in Builtins_WasmToJsWrapperCSA setup-isolate-deserialize.cc
+    #5 0x76efa0000f7e  (<unknown module>)
+    #6 0x76efbf447a0e in Builtins_StringSubstring setup-isolate-deserialize.cc
+    #7 0x76efbf43ea9b in Builtins_ConstructProxy setup-isolate-deserialize.cc
+    #8 0x76efbf43e7de in Builtins_ConstructProxy setup-isolate-deserialize.cc
+    #9 0x7aeff7a2dabc in v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) src/execution/simulator.h:187:12
+    #10 0x7aeff7a3177c in v8::internal::Execution::CallScript(v8::internal::Isolate*, v8::internal::Handle<v8::internal::JSFunction>, v8::internal::Handle<v8::internal::Object>, v8::internal::Handle<v8::internal::Object>) src/execution/execution.cc:517:10
+    #11 0x7aeff6f07ed3 in v8::Script::Run(v8::Local<v8::Context>, v8::Local<v8::Data>) src/api/api.cc:2138:7
+    #12 0x571c4a7e1075 in v8::Shell::ExecuteString(v8::Isolate*, v8::Local<v8::String>, v8::Local<v8::String>, v8::Shell::ReportExceptions, v8::Global<v8::Value>*) src/d8/d8.cc:1007:44
+    #13 0x571c4a813a13 in v8::SourceGroup::Execute(v8::Isolate*) src/d8/d8.cc:4850:10
+    #14 0x571c4a81f23b in v8::Shell::RunMainIsolate(v8::Isolate*, bool) src/d8/d8.cc:5784:37
+    #15 0x571c4a81e694 in v8::Shell::RunMain(v8::Isolate*, bool) src/d8/d8.cc:5693:18
+    #16 0x571c4a821975 in v8::Shell::Main(int, char**) src/d8/d8.cc:6546:18
+    #17 0x7aeff1032082 in __libc_start_main /build/glibc-LcI20x/glibc-2.31/csu/../csu/libc-start.c:308:16
+
+==480==Register values:
+rax = 0x0000000000000000  rbx = 0x00007aeffe5ea8c0  rcx = 0x00007aeff105100b  rdx = 0x0000000000000000
+rdi = 0x0000000000000002  rsi = 0x00007ffe9f2d22e0  rbp = 0x00007ffe9f2d2530  rsp = 0x00007ffe9f2d22e0
+ r8 = 0x0000000000000000   r9 = 0x00007ffe9f2d22e0  r10 = 0x0000000000000008  r11 = 0x0000000000000246
+r12 = 0x0000000000000005  r13 = 0x00000f3ffe09c242  r14 = 0x000079fff04e1000  r15 = 0x000077aff04e2b00
+AddressSanitizer can not provide additional info.
+SUMMARY: AddressSanitizer: ABRT /build/glibc-LcI20x/glibc-2.31/signal/../sysdeps/unix/sysv/linux/raise.c:51:1 in raise
+==480==ABORTING

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -1250,6 +1250,22 @@ class StackAnalyzerTestcase(unittest.TestCase):
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
 
+  def test_v8_csa_dcheck(self):
+    """Test a v8 CSA_DCHECK failure."""
+    data = self._read_test_data('v8_csa_dcheck.txt')
+    expected_type = 'ASSERT'
+    expected_address = ''
+    expected_state = (
+        'CSA_DCHECK failed: Torque assert \'data.wrapper_budget > 0\' failed\n'
+        'wasm-to-js.tq\n')
+
+    expected_stacktrace = data
+    expected_security_flag = True
+
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
   def test_generic_segv(self):
     """Test a SEGV caught by a generic signal handler."""
     data = self._read_test_data('generic_segv.txt')

--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -302,8 +302,9 @@ UBSAN_VPTR_INVALID_DOWNCAST_REGEX = re.compile(
 UBSAN_VPTR_INVALID_OFFSET_REGEX = re.compile(
     r'.*at offset (\d+) within object of type (.*)')
 UBSAN_VPTR_INVALID_VPTR_REGEX = re.compile(r'.*note: object has invalid vptr')
-V8_ABORT_FAILURE_REGEX = re.compile(r'^abort: (CSA_ASSERT failed:.*)')
-V8_ABORT_METADATA_REGEX = re.compile(r'(.*) \[(.*):\d+\]$')
+V8_ABORT_FAILURE_REGEX = re.compile(
+    r'^abort: (CSA_(?:ASSERT|DCHECK) failed: .*)')
+V8_ABORT_METADATA_REGEX = re.compile(r'(.*?) \[(.*):\d+\]$')
 V8_CORRECTNESS_FAILURE_REGEX = re.compile(r'#\s*V8 correctness failure')
 V8_CORRECTNESS_METADATA_REGEX = re.compile(
     r'#\s*V8 correctness ((configs|sources|suppression): .*)')


### PR DESCRIPTION
Extract the CSA_DCHECK message instead of just classifying them as "Abrt" (see https://crbug.com/367623928).