### PR TITLE
stack analyzer: detect centipede stack overflows

### DIFF
--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/centipede_stack_limit_exceeded.txt
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_data/centipede_stack_limit_exceeded.txt
@@ -1,0 +1,57 @@
+[Environment] ASAN_OPTIONS=alloc_dealloc_mismatch=0:allocator_may_return_null=1:allocator_release_to_os_interval_ms=500:allow_user_segv_handler=0:check_malloc_usable_size=0:detect_leaks=1:detect_odr_violation=0:detect_stack_use_after_return=1:fast_unwind_on_fatal=0:handle_abort=2:handle_segv=2:handle_sigbus=2:handle_sigfpe=2:handle_sigill=2:handle_sigtrap=2:print_scariness=1:print_summary=1:print_suppressions=0:quarantine_size_mb=64:redzone=64:strict_memcmp=1:symbolize=0:use_sigaltstack=1
++----------------------------------------Release Build Stacktrace----------------------------------------+
+Command: /mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-release_5d13784cfc85e430de9541077481dcbb17e6d7a3/revisions/fuzztests/v8_module_generation_mvp_fuzztest /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/aa51aaea95657e888e67a960d40f67b98622fd20
+Time ran: 0.9187893867492676
+Starting watchdog thread: timeout_per_input: 0 sec; timeout_per_batch: 0 sec; rss_limit_mb: 0 MB; stack_limit_kb: 0 KB
+Not using RLIMIT_AS; VmSize is 20481Gb, suspecting ASAN/MSAN/TSAN
+Note: Google Test filter = ModuleGenerationTest.TestMVP
+[==========] Running 1 test from 1 test suite.
+[----------] Global test environment set-up.
+[----------] 1 test from ModuleGenerationTest
+[ RUN      ] ModuleGenerationTest.TestMVP
+FUZZTEST_PRNG_SEED=zGuFhxdZNpyYsTHrh6ARX3ZMrz3UuMEfwziZ_reu5lk
+[.] Stack limit set to:131072
+CentipedeSetStackLimit: changing stack_limit_kb to 128
+[.] Replaying /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/aa51aaea95657e888e67a960d40f67b98622fd20
+========= Stack limit exceeded: 982784 > 131072 (byte); aborting
+AddressSanitizer:DEADLYSIGNAL
+=================================================================
+==477==ERROR: AddressSanitizer: ABRT on unknown address 0x0539000001dd (pc 0x7e7fdb58200b bp 0x7ffcb9c87240 sp 0x7ffcb9c86fd0 T0)
+SCARINESS: 10 (signal)
+    #0 0x7e7fdb58200b in raise /build/glibc-LcI20x/glibc-2.31/sysdeps/unix/sysv/linux/raise.c:51:1
+    #1 0x7e7fdb561858 in abort /build/glibc-LcI20x/glibc-2.31/stdlib/abort.c:79:7
+    #2 0x57a2466368b3 in fuzztest::internal::CheckStackLimit(unsigned long) third_party/fuzztest/src/centipede/runner.cc:295:5
+    #3 0x57a246647d51 in HandleOnePc third_party/fuzztest/src/centipede/runner_sancov.cc:210:7
+    #4 0x57a246647d51 in __sanitizer_cov_trace_pc_guard third_party/fuzztest/src/centipede/runner_sancov.cc:312:3
+    #5 0x57a2431663d8 in v8::internal::wasm::grow_stack(v8::internal::Isolate*, void*, unsigned long, unsigned long, unsigned long) src/wasm/wasm-external-refs.cc:1027
+    #6 0x57a2460a5586 in Builtins_WasmHandleStackOverflow setup-isolate-deserialize.cc:0
+==477==Register values:
+rax = 0x0000000000000000  rbx = 0x00007e7fdb53ae00  rcx = 0x00007e7fdb58200b  rdx = 0x0000000000000000
+rdi = 0x0000000000000002  rsi = 0x00007ffcb9c86fd0  rbp = 0x00007ffcb9c87240  rsp = 0x00007ffcb9c86fd0
+ r8 = 0x0000000000000000   r9 = 0x00007ffcb9c86fd0  r10 = 0x0000000000000008  r11 = 0x0000000000000246
+r12 = 0x00007a7fd98ab8a0  r13 = 0x00007d8fdab09080  r14 = 0x0000000000020000  r15 = 0x000057a25192e6c0
+AddressSanitizer can not provide additional info.
+SUMMARY: AddressSanitizer: ABRT (/lib/x86_64-linux-gnu/libc.so.6+0x4300b) (BuildId: 0702430aef5fa3dda43986563e9ffcc47efbd75e)
+==477==ABORTING
+=================================================================
+=== Fuzzing stats
+Elapsed time: 132.005752ms
+Total runs:1
+=================================================================
+=== BUG FOUND!
+../../test/unittests/wasm/module-generation-fuzztest.cc:50: Counterexample found for ModuleGenerationTest.TestMVP.
+The test fails with input:
+argument 0: 2
+argument 1: 3
+argument 2: "ppppppppp\024ppppppppppppppppppppppppppppppppp\367\367pppppppppppppppppppppppppppppY"
+[.] No reproducer output location specified - not writing the reproducer file.
+=================================================================
++----------------------------------------Release Build Unsymbolized Stacktrace (diff)----------------------------------------+
+==477==ERROR: AddressSanitizer: ABRT on unknown address 0x0539000001dd (pc 0x7e7fdb58200b bp 0x7ffcb9c87240 sp 0x7ffcb9c86fd0 T0)
+SCARINESS: 10 (signal)
+    #0 0x7e7fdb58200b  (/lib/x86_64-linux-gnu/libc.so.6+0x4300b) (BuildId: 0702430aef5fa3dda43986563e9ffcc47efbd75e)
+    #1 0x7e7fdb561858  (/lib/x86_64-linux-gnu/libc.so.6+0x22858) (BuildId: 0702430aef5fa3dda43986563e9ffcc47efbd75e)
+    #2 0x57a2466368b3  (/mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-release_5d13784cfc85e430de9541077481dcbb17e6d7a3/revisions/v8_unittests+0x1bc868b3) (BuildId: 99ad5f99961ee7a0)
+    #3 0x57a246647d51  (/mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-release_5d13784cfc85e430de9541077481dcbb17e6d7a3/revisions/v8_unittests+0x1bc97d51) (BuildId: 99ad5f99961ee7a0)
+    #4 0x57a2431663d8  (/mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-release_5d13784cfc85e430de9541077481dcbb17e6d7a3/revisions/v8_unittests+0x187b63d8) (BuildId: 99ad5f99961ee7a0)
+    #5 0x57a2460a5586  (/mnt/scratch0/clusterfuzz/bot/builds/v8-asan_linux-release_5d13784cfc85e430de9541077481dcbb17e6d7a3/revisions/v8_unittests+0x1b6f5586) (BuildId: 99ad5f99961ee7a0)

--- a/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
+++ b/src/clusterfuzz/_internal/tests/core/crash_analysis/stack_parsing/stack_analyzer_test.py
@@ -2584,6 +2584,24 @@ class StackAnalyzerTestcase(unittest.TestCase):
                                   expected_state, expected_stacktrace,
                                   expected_security_flag)
 
+  def test_centipede_stack_limit_exceeded(self):
+    """Test a centipede stack overflow."""
+
+    data = self._read_test_data('centipede_stack_limit_exceeded.txt')
+    data = centipede.trim_logs(data)
+    expected_type = 'Stack-overflow'
+    expected_state = ('v8::internal::wasm::grow_stack\n'
+                      'Builtins_WasmHandleStackOverflow\n'
+                      '/mnt/scratch0/clusterfuzz/bot/builds/'
+                      'v8-asan_linux-release_5d13784cfc85e430de954\n')
+    expected_address = ''
+    expected_stacktrace = data
+    expected_security_flag = False
+
+    self._validate_get_crash_data(data, expected_type, expected_address,
+                                  expected_state, expected_stacktrace,
+                                  expected_security_flag)
+
   def test_centipede_timeout(self):
     """Test a centipede timeout stacktrace (with reporting enabled)."""
     os.environ['REPORT_OOMS_AND_HANGS'] = 'True'
@@ -3554,7 +3572,7 @@ class StackAnalyzerTestcase(unittest.TestCase):
     """Test googletest stacktrace."""
     data = self._read_test_data('googletest.txt')
     expected_type = 'Abrt'
-    expected_state = 'v8::internal::SingleString\nExecuteInputsFromShmem\n'
+    expected_state = 'v8::internal::SingleString\n'
     expected_address = '0x0539000a18ab'
     expected_stacktrace = data
     expected_security_flag = False

--- a/src/clusterfuzz/stacktraces/__init__.py
+++ b/src/clusterfuzz/stacktraces/__init__.py
@@ -939,6 +939,10 @@ class StackParser:
             new_type='Out-of-memory',
             reset=True)
 
+      # Stack overflow detected by Centipede.
+      self.update_state_on_match(
+          CENTIPEDE_STACK_LIMIT_REGEX, line, state, new_type='Stack-overflow')
+
       # V8 sandbox violations.
       self.update_state_on_match(
           V8_SANDBOX_VIOLATION_REGEX,

--- a/src/clusterfuzz/stacktraces/constants.py
+++ b/src/clusterfuzz/stacktraces/constants.py
@@ -76,6 +76,8 @@ CENTIPEDE_TIMEOUT_REGEX = re.compile(r'(?:%s)' % '|'.join([
     r'========= Timeout of \d+ seconds exceeded; exiting',
     r'========= Per-input timeout exceeded:'
 ]))
+CENTIPEDE_STACK_LIMIT_REGEX = re.compile(
+    r'^========= Stack limit exceeded: \d+ > \d+ \(byte\); aborting$')
 CFI_ERROR_REGEX = re.compile(
     r'(.*): runtime error: control flow integrity check for type (.*) '
     r'failed during (.*vtable address ([xX0-9a-fA-F]+)|.*)')
@@ -584,6 +586,8 @@ STACK_FRAME_IGNORE_REGEXES = [
     r'.*libc\+\+/',
     # Clusterfuzz file paths on Windows to ignore.
     r'c:/clusterfuzz/bot/build',
+    # Fuzztest internals.
+    r'.*third_party/fuzztest/',
 
     # Wrappers from honggfuzz/libhfuzz/memorycmp.c.
     r'.*/memorycmp\.c',
@@ -651,6 +655,7 @@ IGNORE_CRASH_TYPES_FOR_ABRT_BREAKPOINT_AND_ILLS = [
     'Fatal error',
     'Security CHECK failure',
     'Security DCHECK failure',
+    'Stack-overflow',
     'Out-of-memory',
     'Timeout',
     'Unreachable code',


### PR DESCRIPTION
Those were previously reported as 'Abort in <random function>', see https://crbug.com/433687472 or https://crbug.com/433565188.